### PR TITLE
Set verifyMatchingIssuers to false by default.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @digitalcredentials/vc-status-list ChangeLog
 
+## 7.2.0 - 
+
+### Changed
+- **BREAKING**: Set the `verifyMatchingIssuers` flag as `false` by default (was
+  previously set to true), since that requirement does not appear in the spec.
+
 ## 7.1.1 - 2023-12-01
 
 ### Fixed

--- a/lib/index.js
+++ b/lib/index.js
@@ -58,7 +58,7 @@ export async function checkStatus({
   documentLoader,
   suite,
   verifyStatusListCredential = true,
-  verifyMatchingIssuers = true
+  verifyMatchingIssuers = false
 } = {}) {
   let result;
   try {


### PR DESCRIPTION
**BREAKING**: Set the `verifyMatchingIssuers` flag as `false` by default (was previously set to true), since that requirement does not appear in the spec.